### PR TITLE
Pod tweaks

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Change history for HTML-Form
 
 {{$NEXT}}
+    - Pod tweaks (GH#17) (Olaf Alders)
 
 6.05      2019-10-04 20:28:20Z
     - Update pod as requested in [RT#87689] (GH#16) (Lance Wicks and Julien

--- a/lib/HTML/Form.pm
+++ b/lib/HTML/Form.pm
@@ -55,8 +55,8 @@ Objects of the C<HTML::Form> class represents a single HTML
 C<E<lt>formE<gt> ... E<lt>/formE<gt>> instance.  A form consists of a
 sequence of inputs that usually have names, and which can take on
 various values.  The state of a form can be tweaked and it can then be
-asked to provide C<HTTP::Request> objects that can be passed to the
-request() method of C<LWP::UserAgent>.
+asked to provide L<HTTP::Request> objects that can be passed to the
+request() method of L<LWP::UserAgent>.
 
 The following methods are available:
 
@@ -100,7 +100,7 @@ to obtain a proper value for C<base> and C<charset>:
 	charset => $response->content_charset,
     );
 
-In fact, the parse() method can parse from an C<HTTP::Response> object
+In fact, the parse() method can parse from an L<HTTP::Response> object
 directly, so the example above can be more conveniently written as:
 
     my $ua = LWP::UserAgent->new;
@@ -108,7 +108,7 @@ directly, so the example above can be more conveniently written as:
     my @forms = HTML::Form->parse($response);
 
 Note that any object that implements a decoded_content(), base() and
-content_charset() method with similar behaviour as C<HTTP::Response> will do.
+content_charset() method with similar behaviour as L<HTTP::Response> will do.
 
 Additional options might be passed in to control how the parse method
 behaves.  The following are all the options currently recognized:
@@ -369,7 +369,7 @@ sub push_input
 =item $form->method( $new_method )
 
 This method is gets/sets the I<method> name used for the
-C<HTTP::Request> generated.  It is a string like "GET" or "POST".
+L<HTTP::Request> generated.  It is a string like "GET" or "POST".
 
 =item $action = $form->action
 
@@ -702,7 +702,7 @@ sub _try
 
 =item $request = $form->make_request
 
-Will return an C<HTTP::Request> object that reflects the current setting
+Will return an L<HTTP::Request> object that reflects the current setting
 of the form.  You might want to use the click() method instead.
 
 =cut
@@ -746,8 +746,8 @@ sub make_request
 =item $request = $form->click( $selector, $x, $y )
 
 Will "click" on the first clickable input (which will be of type
-C<submit> or C<image>).  The result of clicking is an C<HTTP::Request>
-object that can then be passed to C<LWP::UserAgent> if you want to
+C<submit> or C<image>).  The result of clicking is an L<HTTP::Request>
+object that can then be passed to L<LWP::UserAgent> if you want to
 obtain the server response.
 
 If a $selector is specified, we will click on the first clickable input
@@ -1402,7 +1402,7 @@ package HTML::Form::SubmitInput;
 
 Some input types (currently "submit" buttons and "images") can be
 clicked to submit the form.  The click() method returns the
-corresponding C<HTTP::Request> object.
+corresponding L<HTTP::Request> object.
 
 =cut
 

--- a/lib/HTML/Form.pm
+++ b/lib/HTML/Form.pm
@@ -37,9 +37,7 @@ my %type2class = (
     number range color
 ));
 
-=head1 NAME
-
-HTML::Form - Class that represents an HTML form element
+# ABSTRACT: Class that represents an HTML form element
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
Provide links to other modules `L<>` rather than just making them a code `C<>` block.