### PR TITLE
Change the behaviour of find_input in list context

### DIFF
--- a/lib/HTML/Form.pm
+++ b/lib/HTML/Form.pm
@@ -504,7 +504,11 @@ input with the given name and/or type.
 sub find_input
 {
     my($self, $name, $type, $no) = @_;
+    die "Invalid index $no"
+        if defined $no && $no < 1;
     if (wantarray) {
+        warn "find_input called in list context with index specified\n"
+            if defined $no;
 	my @res;
 	my $c;
 	for (@{$self->{'inputs'}}) {

--- a/t/find_input.t
+++ b/t/find_input.t
@@ -1,0 +1,32 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More tests => 7;
+use HTML::Form;
+
+my $html = '<html><body><form></form></body></html>';
+
+my $form = HTML::Form->parse($html, 'http://example.com');
+ok($form, 'form created');
+
+ok(! eval {
+    $form->find_input('submit', 'button', 0);
+    1
+}, 'index 0');
+like($@, qr/Invalid index 0/, 'exception text');
+
+ok(! eval {
+    $form->find_input('submit', 'button', 'a');
+    1
+}, 'index a');
+like($@, qr/Invalid index a/, 'exception text');
+
+{
+    my @warnings;
+    local $SIG{__WARN__} = sub { push @warnings, shift };
+    my @inputs = $form->find_input('submit', 'input', 1);
+    is(scalar @warnings, 1, 'warns');
+    is($warnings[0], "find_input called in list context with index specified\n",
+       'warning text');
+}


### PR DESCRIPTION
and when given non-positive index: warns in the former case, dies in
the latter.