### PR TITLE
add github workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,198 @@
+---
+name: dzil build and test
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+  schedule:
+    - cron: "15 4 * * 0" # Every Sunday morning
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+    container:
+      image: perldocker/perl-tester:5.32
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Tests with coverage
+        env:
+          AUTHOR_TESTING: 1
+          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
+          RELEASE_TESTING: 1
+        run: auto-build-and-test-dist
+      - uses: actions/upload-artifact@master
+        with:
+          name: build_dir
+          path: build_dir
+  test_linux:
+    runs-on: ubuntu-latest
+    name: Perl ${{ matrix.perl-version }} on ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        perl-version:
+          - "5.8"
+          - "5.10"
+          - "5.12"
+          - "5.14"
+          - "5.16"
+          - "5.18"
+          - "5.20"
+          - "5.22"
+          - "5.24"
+          - "5.26"
+          - "5.28"
+          - "5.30"
+          - "5.32"
+          - "5.34"
+          - "5.36"
+    container:
+      image: perldocker/perl-tester:${{ matrix.perl-version }}
+      env:
+        AUTHOR_TESTING: 1
+    steps:
+      - uses: actions/download-artifact@master
+        with:
+          name: build_dir
+          path: .
+      - name: Install deps - older than 5.14
+        if: success() && ( matrix.perl-version == 5.8 || matrix.perl-version == 5.10 || matrix.perl-version == 5.12 )
+        run: >
+          cpm install -g
+          --cpanfile cpanfile
+          --without-develop
+          --with-suggests
+          --show-build-log-on-failure
+      - name: Install deps - 5.14 and newer
+        if: success() && ( matrix.perl-version != 5.8 && matrix.perl-version != 5.10 && matrix.perl-version != 5.12 )
+        run: >
+          cpm install -g
+          --cpanfile cpanfile
+          --with-develop
+          --with-suggests
+          --show-build-log-on-failure
+      - name: Run Tests - older than 5.14
+        if: success() && ( matrix.perl-version == 5.8 || matrix.perl-version == 5.10 || matrix.perl-version == 5.12 )
+        run: prove -lr --jobs 2 t
+      - name: Run Tests - 5.14 and newer
+        if: success() && ( matrix.perl-version != 5.8 && matrix.perl-version != 5.10 && matrix.perl-version != 5.12 )
+        run: prove -lr --jobs 2 t xt
+  test_macos:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: ["macos-latest"]
+        perl-version:
+          - "5.8"
+          - "5.10"
+          - "5.12"
+          - "5.14"
+          - "5.16"
+          - "5.18"
+          - "5.20"
+          - "5.22"
+          - "5.24"
+          - "5.26"
+          - "5.28"
+          - "5.30"
+          - "5.32"
+          - "5.34"
+          - "5.36"
+    name: Perl ${{ matrix.perl-version }} on ${{ matrix.os }}
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set Up Perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl-version }}
+      - uses: actions/download-artifact@master
+        with:
+          name: build_dir
+          path: .
+      - run: perl -V
+      - name: Install deps - older than 5.14
+        if: success() && ( matrix.perl-version == 5.8 || matrix.perl-version == 5.10 || matrix.perl-version == 5.12 )
+        uses: perl-actions/install-with-cpm@v1
+        with:
+          cpanfile: "cpanfile"
+          args: > 
+            --without-develop
+            --with-suggests
+            --with-test
+            --mirror https://cpan.metacpan.org
+            --mirror http://cpan.cpantesters.org
+      - name: Install deps - 5.14 and newer
+        if: success() && ( matrix.perl-version != 5.8 && matrix.perl-version != 5.10 && matrix.perl-version != 5.12 )
+        uses: perl-actions/install-with-cpm@v1
+        with:
+          cpanfile: "cpanfile"
+          args: > 
+            --with-develop
+            --with-suggests
+            --with-test
+            --mirror https://cpan.metacpan.org
+            --mirror http://cpan.cpantesters.org
+      - run: perl -V
+      - name: Run Tests - older than 5.14
+        if: success() && ( matrix.perl-version == 5.8 || matrix.perl-version == 5.10 || matrix.perl-version == 5.12 )
+        run: prove -lr t
+      - name: Run Tests - 5.14 and newer
+        if: success() && ( matrix.perl-version != 5.8 && matrix.perl-version != 5.10 && matrix.perl-version != 5.12 )
+        run: prove -lr t xt
+        env:
+          AUTHOR_TESTING: 1
+  test_windows:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["windows-latest"]
+        perl-version:
+          # https://github.com/shogo82148/actions-setup-perl/issues/223
+          #- "5.10"
+          #- "5.12"
+          - "5.14"
+          - "5.16"
+          - "5.18"
+          - "5.20"
+          - "5.22"
+          - "5.24"
+          - "5.26"
+          - "5.28"
+          - "5.30"
+          - "5.32"
+          # As of 2022-06-06 5.32 is the latest Strawberry Perl
+          # - "5.34"
+          # - "5.36"
+    name: Perl ${{ matrix.perl-version }} on ${{ matrix.os }}
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set Up Perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl-version }}
+          distribution: strawberry
+      - uses: actions/download-artifact@master
+        with:
+          name: build_dir
+          path: .
+      - name: install deps using cpanm
+        uses: perl-actions/install-with-cpanm@v1
+        with:
+          cpanfile: "cpanfile"
+          args: "--mirror https://cpan.metacpan.org --mirror http://cpan.cpantesters.org"
+      - run: perl -V
+      - run: prove -l t xt
+        env:
+          AUTHOR_TESTING: 1

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ SSL
 *.tar.gz
 t/CAN_TALK_TO_OURSELF
 t/live/ENABLED
+.vscode
 xx*

--- a/dist.ini
+++ b/dist.ini
@@ -39,6 +39,7 @@ Encode = 2
 HTTP::Request = 6
 HTTP::Request::Common = 6.03
 perl = 5.008001
+Test::More = 0.96
 URI = 1.10
 [AutoPrereqs]
 [CPANFile]


### PR DESCRIPTION
This is based on the workflow from HTTP::Message. We allow Perl 5.8, so this is turned on. However, several of our xt/ tests require Perl 5.12 or 5.14.

We have to be creative in how we exclude 5.8 from running xt/ tests,
because 5.8 is larger than 5.12.

Also bump Test::More requirement from 0.94 (implicit) to 0.96 to allow
our subtests.