### PR TITLE
Fix the legacy API of "file" inputs

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,8 @@ Change history for HTML-Form
 {{$NEXT}}
     - Remove Authority section from dist.ini (GH#27) (Olaf Alders)
     - Allow buttons to not have a value (GH#8) (Felix Ostmann and Julien Fiegehenn)
+    - The legacy API of FileInput fields now correctly supports setting a
+      custom filename (GH#10) (Gil Magno and Julien Fiegehenn)
 
 6.07      2020-02-21 03:50:52Z
     - Restore =head1 NAME section to pod for HTML::Form

--- a/lib/HTML/Form.pm
+++ b/lib/HTML/Form.pm
@@ -1554,7 +1554,7 @@ sub form_name_value {
 	my $fn = shift @$file;
 	push(@headers, @$file);
 	$file = $f;
-	$filename = $fn unless defined $filename;
+	$filename = $fn;
     }
 
     return ($name => [$file, $filename, @headers]);

--- a/t/file_upload.t
+++ b/t/file_upload.t
@@ -1,0 +1,81 @@
+use strict;
+use warnings;
+use Test::More;
+use HTML::Form;
+
+my ($form, $input);
+
+sub new_form_and_input {
+    $form = HTML::Form->new('POST', '/', 'multipart/form-data');
+    $form->push_input('file', { name => 'document' });
+    ($input) = $form->inputs;
+    return $form, $input;
+}
+
+my $file             = 't/file_upload.txt';
+my $filename         = 'the_uploaded_file.txt';
+
+# Using [$file, $filename] as argument
+
+# $input->value and array refs
+($form, $input) = new_form_and_input;
+$input->value([ $file, $filename ]);
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      'Upload: using $input->value([$file, $filename])' );
+
+# $input->file and array refs
+($form, $input) = new_form_and_input;
+$input->file([ $file, $filename ]);
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      'Upload: using $input->file([$file, $filename])' );
+
+# $form->value and array refs
+($form, $input) = new_form_and_input;
+$form->value('document', [ $file, $filename ]);
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      q/Upload: using $form->value('document', [$file, $filename])/ );
+
+# Using [$file, $filename, Content => 'inline content'] as argument
+
+# $input->value and array refs
+($form, $input) = new_form_and_input;
+$input->value([ $file, $filename, Content => 'inline content' ]);
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      q/Upload: using $input->value([$file, $filename, Content => '?'])/ );
+
+# $input->file and array refs
+($form, $input) = new_form_and_input;
+$input->file([ $file, $filename, Content => 'inline content' ]);
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      q/Upload: using $input->file([$file, $filename, Content => '?'])/ );
+
+# $form->value and array refs
+($form, $input) = new_form_and_input;
+$form->value('document', [ $file, $filename, Content => 'inline content' ]);
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+q/Upload: using $form->value('document', [$file, $filename, Content => '?'])/ );
+
+# Using methods (file, filename, content) directly
+
+# 'file' informed directly
+($form, $input) = new_form_and_input;
+$input->file($file);
+like( $form->make_request->as_string, qr! filename="$file" !x,
+      "Upload: 'file' informed directly and used as 'filename'" );
+
+# 'file' and 'filename' informed directly
+($form, $input) = new_form_and_input;
+$input->file($file);
+$input->filename($filename);
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      "Upload: 'file' and 'filename' informed directly" );
+
+# 'file', 'filename' and 'content' informed directly
+($form, $input) = new_form_and_input;
+$input->file($file);
+$input->filename($filename);
+$input->content('inline content');
+like( $form->make_request->as_string, qr! filename="$filename" !x,
+      "Upload: 'file', 'filename' and 'content' informed directly" );
+
+done_testing;

--- a/t/file_upload.txt
+++ b/t/file_upload.txt
@@ -1,0 +1,2 @@
+First line.
+Second line.


### PR DESCRIPTION
I've rebased the original gisle/HTML-Form#10. Closes #10. This should be merged before #30 so I can amend the tests there.