### PR TITLE
set spelling test language to en_US

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -84,7 +84,7 @@ trustme = HTML::Form => qr/^(?:fixup|new|push_input|uri)$/
 
 [Test::PodSpelling]
 wordlist = Pod::Wordlist
-spell_cmd = aspell list
+spell_cmd = aspell --master=en_US list
 stopword = autocomplete
 stopword = CGI
 stopword = checkbox


### PR DESCRIPTION
This is so developers with other locales (like en_GB) can run this
without fails.