### PR TITLE
Replace "use vars" with "our"

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Change history for HTML-Form
 
 {{$NEXT}}
 
+    - Replace "use vars" with "our" (GH#34) (James Raspass)
+
 6.08      2022-08-14 09:26:10Z
     - Remove Authority section from dist.ini (GH#27) (Olaf Alders)
     - Allow buttons to not have a value (GH#8) (Felix Ostmann and Julien Fiegehenn)

--- a/META.json
+++ b/META.json
@@ -61,8 +61,7 @@
             "Test::More" : "0.96",
             "URI" : "1.10",
             "perl" : "5.008001",
-            "strict" : "0",
-            "vars" : "0"
+            "strict" : "0"
          }
       },
       "test" : {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,7 +25,6 @@ my %WriteMakefileArgs = (
     "Test::More" => "0.96",
     "URI" => "1.10",
     "strict" => 0,
-    "vars" => 0
   },
   "TEST_REQUIRES" => {
     "ExtUtils::MakeMaker" => 0,
@@ -57,7 +56,6 @@ my %FallbackPrereqs = (
   "URI" => "1.10",
   "lib" => 0,
   "strict" => 0,
-  "vars" => 0,
   "warnings" => 0
 );
 

--- a/cpanfile
+++ b/cpanfile
@@ -10,7 +10,6 @@ requires "Test::More" => "0.96";
 requires "URI" => "1.10";
 requires "perl" => "5.008001";
 requires "strict" => "0";
-requires "vars" => "0";
 
 on 'test' => sub {
   requires "ExtUtils::MakeMaker" => "0";

--- a/lib/HTML/Form.pm
+++ b/lib/HTML/Form.pm
@@ -5,7 +5,6 @@ use URI;
 use Carp ();
 use Encode ();
 
-use vars qw($VERSION);
 our $VERSION = '6.09';
 
 my %form_tags = map {$_ => 1} qw(input textarea button select option);

--- a/t/form.t
+++ b/t/form.t
@@ -158,9 +158,8 @@ ok(@warn, 0);
 # Try to parse form HTTP::Response directly
 {
     package MyResponse;
-    use vars qw(@ISA);
     require HTTP::Response;
-    @ISA = ('HTTP::Response');
+    our @ISA = ('HTTP::Response');
 
     sub base { "http://www.example.com" }
 }


### PR DESCRIPTION
Use of this pragma is discouraged in favour of "our" under 5.06+.

This dist already uses "our" elsewhere.