### PR TITLE
Exclude dist.ini from release tarball

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -6,6 +6,7 @@ copyright_year      = 1998
 
 [Git::GatherDir]
 exclude_filename = cpanfile
+exclude_filename = dist.ini
 exclude_filename = LICENSE
 exclude_filename = Makefile.PL
 exclude_filename = META.json


### PR DESCRIPTION
dzil is an authoring tool, dist.ini has no place in the release artifact.