### PR TITLE
parse select inputs that have no name #2

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,10 @@ Change history for HTML-Form
     - Use "croak" instead of "die" to show errors from the perspective of the
       caller [RT#20499] (GH#29) (Julien Fiegehenn)
     - Remove the executable bit from a couple of tests (GH#41) (James Raspass)
+    - <option>s within select fields without a name no longer get merged into
+      the previous select field (GH#2) (Julien Fiegehenn)
+    - find_input() can now take a reference to undef to explicitly find inputs
+      that have no name (GH#2) (Julien Fiegehenn)
 
 6.09      2022-08-14 22:16:37Z
 


### PR DESCRIPTION
In order to do this, I had to allow find_input to find inputs that have
no name. Before, we treated an undef in the name (actually, the
'selector') as an instruction not to match the name. To put option
elements into the correct surrounding select, we have to match them by
their name, including when there is no name.

Two of the tests I have added don't produce what I would expect. I think
this is another bug. It seems we include unnamed fields that have a
value in the query string, as long as they have a name attribute. This
leads to query strings such as 'name=value&=value'. The W3 specification
explicitly says that only element that have names should be submitted,
so I believe this behaviour is wrong.

See https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#naming-form-controls%3A-the-name-attribute.

Please let me know what you think about the TODO tests.

Closes #2 