### PR TITLE
modify expected output of parsed form to reflect unix file format

### DIFF
--- a/t/form.t
+++ b/t/form.t
@@ -85,10 +85,10 @@ EOT
 
 is( $f->click->as_string, <<'EOT');
 POST http://localhost/
-Content-Length: 86
+Content-Length: 80
 Content-Type: application/x-www-form-urlencoded
 
-i.x=1&i.y=1&c=on&r=b&t=&p=&tel=&date=&h=xyzzy&f=&x=&a=%0D%0Aabc%0D%0A+++&s=bar&m=a&m=b
+i.x=1&i.y=1&c=on&r=b&t=&p=&tel=&date=&h=xyzzy&f=&x=&a=%0Aabc%0A+++&s=bar&m=a&m=b
 EOT
 
 is( @warn, 1 );


### PR DESCRIPTION
Addresses following issue:

```
#   Failed test at t/form.t line 86.
#          got: 'POST http://localhost/
# Content-Length: 80
# Content-Type: application/x-www-form-urlencoded
# 
# i.x=1&i.y=1&c=on&r=b&t=&p=&tel=&date=&h=xyzzy&f=&x=&a=%0Aabc%0A+++&s=bar&m=a&m=b
# '
#     expected: 'POST http://localhost/
# Content-Length: 86
# Content-Type: application/x-www-form-urlencoded
# 
# i.x=1&i.y=1&c=on&r=b&t=&p=&tel=&date=&h=xyzzy&f=&x=&a=%0D%0Aabc%0D%0A+++&s=bar&m=a&m=b
# '
# Looks like you failed 1 test of 134.
t/form.t ............... 
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/134 subtests
```