### PR TITLE
normalize newlines in forms to CRLF

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Change history for HTML-Form
 
 {{$NEXT}}
+    - Fix CRLF normalization with HTTP::Message 7.00
 
 6.11      2023-02-11 11:49:19Z
     - Perl::Tidy-ed the entire codebase (GH#42) (Julien Fiegehenn)

--- a/lib/HTML/Form/Input.pm
+++ b/lib/HTML/Form/Input.pm
@@ -113,6 +113,8 @@ sub form_name_value {
     return if $self->disabled;
     my $value = $self->value;
     return unless defined $value;
+    s/\x0d?\x0a|\x0d/\x0d\x0a/g
+      for $name, $value;
     return ( $name => $value );
 }
 


### PR DESCRIPTION
HTTP::Message < 7.00 normalized newlines in requests to CRLF. This has been removed. Based on the [HTML
spec](https://html.spec.whatwg.org/#converting-an-entry-list-to-a-list-of-name-value-pairs) and [URL spec](https://url.spec.whatwg.org/#urlencoded-serializing), the CRLF normalization should be in the HTML layer. So the change in HTTP::Message is correct, and HTML::Form should be handling the normalization.

Add normalization of lone \r or \n into \r\n, as defined in the HTML spec.

Older HTTP::Message versions will do their own normalization. That will end up being a no-op, so we will still be compatible with those older versions.